### PR TITLE
security: checksum mismatch in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/golang/protobuf v1.4.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0
 	github.com/layer5io/gokit v0.1.15
-	github.com/layer5io/learn-layer5/smi-conformance v0.0.0-20201022191033-40468652a54f
 	github.com/spf13/viper v1.7.0
 	go.opencensus.io v0.22.3 // indirect
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
@@ -22,9 +21,5 @@ require (
 	google.golang.org/grpc v1.31.0
 	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0
-	helm.sh/helm/v3 v3.3.4
-	k8s.io/api v0.18.8
-	k8s.io/apimachinery v0.18.8
 	k8s.io/client-go v0.18.8
-	rsc.io/letsencrypt v0.0.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -497,13 +497,9 @@ github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 h1:SOEGU9fKiNWd/HOJuq
 github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
-github.com/layer5io/gokit v0.1.14 h1:Ki5T72jdKhxiburVdQ9UUVr5Rok/egluB0dXoadulqc=
-github.com/layer5io/gokit v0.1.14/go.mod h1:kqwXJ5JZqHv74UCH1pVyDdpLT8muaUyRVu58WWu6wcY=
 github.com/layer5io/gokit v0.1.15 h1:LlKvIa0seafCHNnmrz089sNl3DXV0WMP5aiRLAttBJU=
 github.com/layer5io/gokit v0.1.15/go.mod h1:AGOtt6fbKqg1Q1a9xY7cicF10s1MZJCzBiHg6PCRQMM=
 github.com/layer5io/kuttl v0.4.1-0.20200806180306-b7e46afd657f/go.mod h1:UmrVd7x+bNVKrpmKgTtfRiTKHZeNPcMjQproJ0vGwhE=
-github.com/layer5io/learn-layer5/smi-conformance v0.0.0-20200916172547-79cf11334bd7 h1:jglAwWM8pbUN43HL3tpFYPkWLFNpj1/ZsJISdqKhavg=
-github.com/layer5io/learn-layer5/smi-conformance v0.0.0-20200916172547-79cf11334bd7/go.mod h1:LpewBZnN0QDRcC2fDiBVK+iByfFyf2HJM1B2h0rTMZo=
 github.com/layer5io/learn-layer5/smi-conformance v0.0.0-20201022191033-40468652a54f h1:ZwVdDIb9RRXCRfRNUGOgwcyn5WrjfJi7NV64SwQ0Gvo=
 github.com/layer5io/learn-layer5/smi-conformance v0.0.0-20201022191033-40468652a54f/go.mod h1:LpewBZnN0QDRcC2fDiBVK+iByfFyf2HJM1B2h0rTMZo=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -1087,8 +1083,6 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
-helm.sh/helm/v3 v3.3.1 h1:uc+ZUthJnWNSwqyIv1KCdQm0ewi0eAf6oRaWG2X1oo0=
-helm.sh/helm/v3 v3.3.1/go.mod h1:CyCGQa53/k1JFxXvXveGwtfJ4cuB9zkaBSGa5rnAiHU=
 helm.sh/helm/v3 v3.3.4 h1:tbad6WQVMxEw1HlVBvI2rQqOblmI5lgXOrWAMwJ198M=
 helm.sh/helm/v3 v3.3.4/go.mod h1:CyCGQa53/k1JFxXvXveGwtfJ4cuB9zkaBSGa5rnAiHU=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
Signed-off-by: Kush Trivedi <kushthedude@gmail.com>

The build is failing in CI due to check-sum mismatch in go.mod & go.sum

More info here https://github.com/layer5io/meshery-nginx-sm/runs/1333695817?check_suite_focus=true